### PR TITLE
Implement tournament selection for deme instance selection

### DIFF
--- a/Representation/exp.py
+++ b/Representation/exp.py
@@ -197,6 +197,26 @@ def select_top_k(deme: Deme, k: int) -> List[Instance]:
     sorted_instances = sorted(deme.instances, key=lambda inst: inst.score, reverse=True)
     return sorted_instances[:k]
 
+def tournament_selection(deme: Deme, k:int, tournament_size: int) -> List[Instance]:
+    """
+    tournament_selection: Selects instances from the deme using tournament selection.
+    Args:
+        deme (Deme): The deme containing instances.
+        k (int): The number of instances to select.
+        tournament_size (int): The size of each tournament.
+    Returns: A list of selected instances.
+    """
+    selected_instances = []
+    num_instances = len(deme.instances)
+
+    K = min(k, num_instances)
+    for _ in range(K):
+        tournament = random.sample(deme.instances, min(tournament_size, num_instances))
+        winner = max(tournament, key=lambda inst: inst.score)
+        selected_instances.append(winner)
+
+    return selected_instances
+
 def knobs_from_truth_table(ITable: List[dict]) -> List[Knob]:
     """
     Given a truth table (list of dict rows), extract:


### PR DESCRIPTION
## Title
Add tournament selection strategy for deme instance selection

## Description
This PR adds a tournament selection strategy as an alternative to the existing top-k selection method. The new approach selects instances through randomized tournaments while still favoring higher-scoring individuals.

## Motivation and Context
The existing top-k selection method is deterministic and may reduce diversity during selection. Tournament selection introduces controlled randomness, which helps maintain diversity and can improve exploration in evolutionary processes without removing the existing selection strategy.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
