### PR TITLE
Implemented Quantale Based Mutation

### DIFF
--- a/DependencyMiner/miner.py
+++ b/DependencyMiner/miner.py
@@ -1,3 +1,8 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from Representation.helpers import TreeNode, parse_sexpr, tokenize
 
 import collections

--- a/Representation/helpers.py
+++ b/Representation/helpers.py
@@ -104,3 +104,52 @@ def exclude_one_symbol(expr:str , symbol_to_remove:str)->str:
 
 def isOP(token: str) -> bool:
     return token in ['AND', 'OR', 'NOT']
+
+def get_top_level_features(s_expr_str):
+    """
+    Parses "(AND A (OR B C) D)" into -> ["A", "(OR B C)", "D"]
+    """
+    content = s_expr_str.strip()
+    if content.startswith("(AND"):
+        content = content[4:-1].strip()
+    elif content.startswith("(OR"):
+        content = content[3:-1].strip()
+    else:
+        return s_expr_str
+
+    
+    features = []
+    buffer = ""
+    balance = 0
+    
+    for char in content:
+        if char == '(':
+            balance += 1
+        elif char == ')':
+            balance -= 1
+            
+        if char == ' ' and balance == 0:
+            if buffer.strip():
+                features.append(buffer.strip())
+            buffer = ""
+        else:
+            buffer += char
+            
+    if buffer.strip():
+        features.append(buffer.strip())
+        
+    return features
+
+def isSymbol(s_expression):
+    s_expression = s_expression.strip()
+    # Single token -> symbol
+    if "(" not in s_expression and ")" not in s_expression:
+        return True
+    # Must start with '(' to be a proper expression
+    if not s_expression.startswith("("):
+        return True
+    # Treat (NOT ...) as a symbol
+    if s_expression.startswith("(NOT"):
+        return True
+    # Nested only if it begins with (AND ...) or (OR...)
+    return  not (s_expression.startswith("(AND") or s_expression.startswith("(OR"))

--- a/Variation_quantale/crossover.py
+++ b/Variation_quantale/crossover.py
@@ -8,43 +8,10 @@ from Representation.representation import (Quantale, Instance,
                                            knobs_from_truth_table)
 from Representation.csv_parser import load_truth_table
 from Representation.sampling import sample_from_TTable
-from Representation.helpers import tokenize
+from Representation.helpers import tokenize, get_top_level_features
 from typing import Any, Set
 import random
 
-
-def get_top_level_features(s_expr_str):
-    """
-    Parses "(AND A (OR B C) D)" into -> ["A", "(OR B C)", "D"]
-    """
-    content = s_expr_str.strip()
-    if content.startswith("(AND"):
-        content = content[4:-1].strip()
-    elif content.startswith("(OR"):
-        content = content[3:-1].strip()
-
-    
-    features = []
-    buffer = ""
-    balance = 0
-    
-    for char in content:
-        if char == '(':
-            balance += 1
-        elif char == ')':
-            balance -= 1
-            
-        if char == ' ' and balance == 0:
-            if buffer.strip():
-                features.append(buffer.strip())
-            buffer = ""
-        else:
-            buffer += char
-            
-    if buffer.strip():
-        features.append(buffer.strip())
-        
-    return features
 
 class VariationQuantale(Quantale):
     def __init__(self, m1, m2, stv_values):

--- a/Variation_quantale/mutation.py
+++ b/Variation_quantale/mutation.py
@@ -1,0 +1,241 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Representation.representation import (Quantale, Instance,
+                                           Deme, Hyperparams,
+                                           knobs_from_truth_table)
+from Representation.csv_parser import load_truth_table
+from Representation.helpers import tokenize, get_top_level_features, isSymbol
+from reduct.enf.main import reduce
+from hyperon import MeTTa
+from typing import Any, Set
+import random
+
+
+
+class Mutation(Quantale):
+    def __init__(self, instance: Instance, stv_values: dict, hyperparams: Hyperparams):
+        super().__init__()
+        self.instance = instance
+        self.instance_value = instance.value
+        self.base_op = self.get_base_OP()
+        self.stv_values = stv_values
+        self.mutation_rate = hyperparams.mutation_rate
+        self.reference_order = get_top_level_features(self.instance_value)
+        self.instance_vector = set(self.reference_order)
+
+
+    def product(self, expression_str: str) -> str:
+        """
+        Recursively decides whether to keep or remove features.
+        Returns: The pruned string, or None if removed completely.
+        """
+        if isSymbol(expression_str):
+            score = self._get_composite_score(expression_str)
+            prob_keep = score if score > 0 else self.mutation_rate
+            
+            if random.random() < prob_keep:
+                return expression_str
+            return None # Prune symbol
+
+        score = self._get_composite_score(expression_str)
+        
+        prob_keep_block = score if score > 0 else 0.7
+        if random.random() >= prob_keep_block:
+             return None # Prune whole block
+        
+        children = get_top_level_features(expression_str)
+        clean_str = expression_str.strip()
+        op = "AND" if clean_str.startswith("(AND") else "OR" if clean_str.startswith("(OR") else self.base_op
+        
+        surviving_children = []
+        for child in children:
+            result = self.product(child)
+            if result:
+                surviving_children.append(result)
+        
+        if not surviving_children:
+            return None
+            
+        return f"({op} {' '.join(surviving_children)})"
+
+    def join(self, feature: str) -> str:
+        """Transforms 'C' into '(NOT C)'."""
+        if feature.startswith("(NOT ") and feature.endswith(")"):
+            return feature[5:-1]
+        return f"(NOT {feature})"
+    
+    def residium(self, parent1, parent2):
+        return super().residium(parent1, parent2)
+    
+    def unit(self):
+        return super().unit()
+        
+    def get_base_OP(self) -> str:
+        content = self.instance_value.strip()
+        if content.startswith("(") and content.endswith(")"):
+            content = content[1:-1].strip()
+            
+        parts = content.split(' ', 1)
+        return parts[0]
+        
+    def execute_multiplicative(self) -> str:
+        """
+        Recursive Multiplicative Mutation.
+        Traverses tree and prunes weak branches/leaves.
+        """
+        keep_mask = []
+        
+        for feat in self.reference_order:
+            result = self.product(feat)
+            if result:
+                keep_mask.append(result)
+                
+        if not keep_mask:
+             return f"({self.base_op})"
+             
+        instance_exp = f"({self.base_op} {' '.join(keep_mask)})"
+        new_instance = Instance(
+            value=instance_exp,
+            id=random.randint(1000, 9999),
+            score=0.0,
+            knobs=[k for k in self.instance.knobs if k.symbol in tokenize(instance_exp)]
+        )
+        return new_instance
+
+    def _mutate_expression(self, expression_str: str) -> str:
+        """
+        Recursively mutates an expression string.
+        1. If symbol: Check STV, maybe FLIP.
+        2. If expression: 
+           - Chance to Negate WHOLE expression.
+           - Else: Recursively mutate inside.
+        """
+        if isSymbol(expression_str):
+            score = self._get_composite_score(expression_str) 
+            mutation_prob = self.mutation_rate * (1.1 - score)
+            
+            if random.random() < mutation_prob:
+                return self.join(expression_str)
+            return expression_str
+
+        score = self._get_composite_score(expression_str)
+        mutation_prob = self.mutation_rate * (1.1 - score)
+        
+        if random.random() < mutation_prob:
+            return self.join(expression_str)
+        
+        children = get_top_level_features(expression_str)
+        clean_str = expression_str.strip()
+        if clean_str.startswith("(AND"):
+            operator = "AND"
+        elif clean_str.startswith("(OR"):
+            operator = "OR"
+        else:
+            return expression_str
+        
+        mutated_children = [self._mutate_expression(child) for child in children]
+        
+        return f"({operator} {' '.join(mutated_children)})"
+
+    def execute_additive(self, base_mutation_rate=None) -> str:
+        """
+        Additive Mutation: FLIPS genes or Mutates nested structures recursivley.
+        """
+        if base_mutation_rate:
+            self.mutation_rate = base_mutation_rate
+
+        new_features = []
+        
+        for feat in self.reference_order:
+            mutated_feat = self._mutate_expression(feat)
+            new_features.append(mutated_feat)
+
+        instance_exp = f"({self.base_op} {' '.join(new_features)})"
+        present_symbols = set(tokenize(instance_exp))
+        parent_knobs = {k.symbol: k for k in self.instance.knobs}
+        new_knobs = [parent_knobs[sym] for sym in present_symbols if sym in parent_knobs]
+        
+        new_instance = Instance(
+            value=instance_exp,
+            id=random.randint(1000, 9999),
+            score=0.0,
+            knobs=new_knobs
+        )
+        return new_instance
+    
+    
+    def _get_composite_score(self, feature: str) -> float:
+        """
+        Calculates a score for a feature.
+        If atomic (e.g., "A") and in STV, returns that score.
+        If complex, averages scores of atomic children.
+        """
+        if feature in self.stv_values:
+            s, c = self.stv_values[feature]
+            return (s + c) / 2.0
+            
+        if feature.startswith("("):
+            atoms = get_top_level_features(feature)
+            scores = []
+            for atom in atoms:
+                if atom in self.stv_values:
+                    s, c = self.stv_values[atom]
+                    scores.append((s + c) / 2.0)
+                else:
+                    scores.append(self.mutation_rate)            
+            if scores:
+                return sum(scores) / len(scores)
+
+        return self.mutation_rate
+
+
+
+
+
+
+if __name__ == "__main__":
+    hyperparam = Hyperparams(mutation_rate=0.3, crossover_rate=0.7, neighborhood_size=10, num_generations=10)
+    knob_vals, target_vals = load_truth_table('example_data/test_bin.csv', output_col='O')
+    knobs = knobs_from_truth_table(knob_vals)
+    stv = {
+    "A": (0.95, 0.95), # Strong
+    "B": (0.80, 0.80), # Good
+    "C": (0.20, 0.20),  # Weak
+    "D": (0.35, 0.50),  # Weak
+    "E": (0.46, 0.50),  # Weak
+    "F": (0.46, 0.50),  # Weak
+    "(OR D (AND E F))": (0.7, 0.5) # Moderate
+    }
+    # parent = "(AND A B C)"
+    parent = Instance(value=f"(AND A B C (OR D (AND E F)))", id=0, score=0.0, knobs=knobs)
+
+    metta = MeTTa()
+    mutator = Mutation(parent, stv, hyperparam)
+    print(f"Parent: {parent.value}")
+
+    # 1. Generate Multiplicative Child (The Pruned One)
+    # C is likely to be removed.
+    child_mult = mutator.execute_multiplicative()
+    print(f"Multiplicative Child: {child_mult.value} | Knobs: {[k.symbol for k in child_mult.knobs]}")
+
+    # 2. Generate Additive Child (The Noisy One)
+    # Might add (NOT A) or (NOT C)
+    child_add = mutator.execute_additive()
+    print(f"Additive Child:       {child_add.value} | Knobs: {[k.symbol for k in child_add.knobs]}")
+    # reduced = reduce(metta, child_add.value)
+    # print(f"Reduced Additive:     {reduced}")
+
+#     exemplar = Instance(value=f"(AND A B C D E F)", id=0, score=0.0, knobs=knobs)
+    
+    # demes = sample_from_TTable('example_data/test_bin.csv', hyperparam, exemplar, knobs, target_vals, output_col='O')
+    # deme1 = demes[0]
+    # inst1, inst2 = deme1.instances[0], deme1.instances[1]
+    # print("--- Parent Instances ---")
+    # print(f"Instance 1: {inst1.value} | Knobs: {[k.symbol for k in inst1.knobs]}")
+    # print(f"Instance 1: {inst2.value} | Knobs: {[k.symbol for k in inst2.knobs]}")
+    # inst1 = Instance(value=f"(AND A B C D (OR (NOT A) E) F)", id=0, score=0.0, knobs=knobs)
+    # inst2 = Instance(value=f"(AND A B E F)", id=0, score=0.0, knobs=knobs)
+    # stv1 = {"A": (0.7, 0.7), "B": (0.8, 0.8),"E": (0.2, 0.2), "F": (0.4, 0.4), "(OR (NOT A) E)": (0.6, 0.6)}

--- a/Variation_quantale/tests/crossover_test.py
+++ b/Variation_quantale/tests/crossover_test.py
@@ -46,11 +46,11 @@ class TestVariationQuantale(unittest.TestCase):
 
         # Fixed STV values to make mask probabilities predictable-ish
         self.stv_values = {
-            "A": (0.9, 0.9),          # likely included
-            "B": (0.8, 0.8),          # likely included
-            "C": (0.2, 0.2),          # less likely
-            "D": (0.5, 0.5),          # 0.5 probability
-            "(OR C D)": (0.7, 0.7),   # for the nested expression
+            "A": (0.9, 0.9),          
+            "B": (0.8, 0.8),          
+            "C": (0.2, 0.2),          
+            "D": (0.5, 0.5), 
+            "(OR C D)": (0.7, 0.7),   
         }
 
         random.seed(0)

--- a/Variation_quantale/tests/mutation_test.py
+++ b/Variation_quantale/tests/mutation_test.py
@@ -1,0 +1,152 @@
+import unittest
+import random
+from Variation_quantale.mutation import Mutation
+from Representation.representation import Instance, Hyperparams, Knob
+from Representation.helpers import tokenize
+
+class MutationTestCase(unittest.TestCase):
+    def setUp(self):
+        random.seed(42)
+
+        self.knobs = [
+            Knob(symbol="A", id=1, Value=[True, False]),
+            Knob(symbol="B", id=2, Value=[True, True]),
+            Knob(symbol="C", id=3, Value=[False, True]),
+            Knob(symbol="D", id=4, Value=[True, False]),
+            Knob(symbol="E", id=5, Value=[False, False]),
+            Knob(symbol="F", id=6, Value=[True, True]),
+        ]
+
+        self.parent_expr = "(AND A B C (OR D (AND E F)))"
+        self.parent = Instance(
+            value=self.parent_expr,
+            id=0,
+            score=0.0,
+            knobs=self.knobs,
+        )
+
+        self.stv = {
+            "A": (0.95, 0.95),  # Strong
+            "B": (0.80, 0.80),  # Good
+            "C": (0.20, 0.20),  # Weak
+            "D": (0.35, 0.50),  # Weak
+            "E": (0.46, 0.50),  # Weak
+            "F": (0.46, 0.50),  # Weak
+            "(OR D (AND E F))": (0.7, 0.5),  # Moderate
+        }
+
+        self.hyper = Hyperparams(
+            mutation_rate=0.3,
+            crossover_rate=0.7,
+            neighborhood_size=10,
+            num_generations=10,
+        )
+
+        self.mutator = Mutation(self.parent, self.stv, self.hyper)
+
+
+    def test_get_base_OP(self):
+        self.assertEqual(self.mutator.base_op, "AND")
+
+    def test_reference_order_parsed(self):
+        self.assertIn("A", self.mutator.reference_order)
+        self.assertIn("B", self.mutator.reference_order)
+        self.assertIn("C", self.mutator.reference_order)
+        self.assertIn("(OR D (AND E F))", self.mutator.reference_order)
+        self.assertEqual(len(self.mutator.reference_order), 4)
+
+    # ---------- join (NOT flipping) ----------
+
+    def test_join_negates_symbol(self):
+        self.assertEqual(self.mutator.join("C"), "(NOT C)")
+
+    def test_join_unnests_negated_symbol(self):
+        self.assertEqual(self.mutator.join("(NOT C)"), "C")
+
+    # ---------- composite score ----------
+
+    def test_get_composite_score_atomic(self):
+        score_A = self.mutator._get_composite_score("A")
+        self.assertAlmostEqual(score_A, (0.95 + 0.95) / 2.0)
+
+    def test_get_composite_score_complex_uses_children(self):
+        score_complex = self.mutator._get_composite_score("(OR D (AND E F))")
+        self.assertAlmostEqual(score_complex, (0.7 + 0.5) / 2.0)
+
+    def test_get_composite_score_fallback_mutation_rate(self):
+        score_unknown = self.mutator._get_composite_score("(AND X Y)")
+        self.assertAlmostEqual(score_unknown, self.hyper.mutation_rate)
+
+    # ---------- multiplicative mutation ----------
+
+    def test_execute_multiplicative_returns_instance(self):
+        child = self.mutator.execute_multiplicative()
+        self.assertIsInstance(child, Instance)
+        self.assertIsInstance(child.value, str)
+
+    def test_execute_multiplicative_operator_preserved(self):
+        child = self.mutator.execute_multiplicative()
+        self.assertTrue(child.value.startswith("(AND"))
+        self.assertTrue(child.value.endswith(")"))
+
+    def test_execute_multiplicative_knobs_subset_of_parent(self):
+        child = self.mutator.execute_multiplicative()
+        parent_symbols = {k.symbol for k in self.parent.knobs}
+        child_symbols = {k.symbol for k in child.knobs}
+        self.assertTrue(child_symbols.issubset(parent_symbols))
+
+    def test_execute_multiplicative_empty_kept_uses_base_op_only(self):
+        hyper_low = Hyperparams(
+            mutation_rate=0.0001,
+            crossover_rate=0.7,
+            neighborhood_size=10,
+            num_generations=10,
+        )
+        stv_zero = {k: (0.0, 0.0) for k in tokenize(self.parent_expr)}
+        mutator_low = Mutation(self.parent, stv_zero, hyper_low)
+
+        # product() is stochastic, but with such low rate and zero scores,
+        # it's extremely likely all will be pruned; we assert the fallback format
+        child = mutator_low.execute_multiplicative()
+        self.assertEqual(child, f"({mutator_low.base_op})")
+
+    # ---------- additive mutation ----------
+
+    def test_execute_additive_returns_instance(self):
+        child = self.mutator.execute_additive()
+        self.assertIsInstance(child, Instance)
+
+    def test_execute_additive_operator_preserved(self):
+        child = self.mutator.execute_additive()
+        self.assertTrue(child.value.startswith("(AND"))
+        self.assertTrue(child.value.endswith(")"))
+
+    def test_execute_additive_knobs_match_present_symbols(self):
+        child = self.mutator.execute_additive()
+        present_symbols = set(tokenize(child.value))
+        child_symbols = {k.symbol for k in child.knobs}
+        self.assertTrue(child_symbols.issubset(present_symbols))
+
+    def test_execute_additive_uses_custom_base_mutation_rate(self):
+        child = self.mutator.execute_additive(base_mutation_rate=0.9)
+        self.assertIn("(NOT", child.value)
+
+    # ---------- internal _mutate_expression ----------
+
+    def test_mutate_expression_atomic_returns_string(self):
+        mutated = self.mutator._mutate_expression("A")
+        self.assertIsInstance(mutated, str)
+
+    def test_mutate_expression_complex_preserves_structure(self):
+        expr = "(AND A (OR B C))"
+        mutated = self.mutator._mutate_expression(expr)
+        self.assertTrue(mutated.startswith("("))
+        self.assertTrue(mutated.endswith(")"))
+
+    def test_product_on_atomic_symbol(self):
+        result = self.mutator.product("A")
+        self.assertIn(result, ("A", None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,13 @@
+contourpy==1.3.2
+cycler==0.12.1
+fonttools==4.61.1
 hyperon==0.2.9
+kiwisolver==1.4.9
+matplotlib==3.10.8
+networkx==3.4.2
+numpy==2.2.6
+packaging==26.0
+pillow==12.1.0
+pyparsing==3.3.2
+python-dateutil==2.9.0.post0
+six==1.17.0


### PR DESCRIPTION
…rturbation

<!--- Provide a general summary of your changes in the Title above -->

## Description
Implemented quantale-based mutation that uses additive and multiplicative perturbation. The additive property (join operator) negates a node based on its STV score (composite score) while recursively going into nested expressions. The same is true for the multiplicative property (product operator) the difference is that the product operator prunes the node instead of negating it. If their STVs are not recorded by the EDA the program defaults to the `mutation_rate `given in the hyperparameter. 

## Motivation and Context
- This is the second part of the VariationalQuantale.

## How Has This Been Tested?
- Each component and edge case have been coverd via unittest in its own test file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
